### PR TITLE
added dedicated thread fiber benchmark

### DIFF
--- a/Helios.sln
+++ b/Helios.sln
@@ -49,6 +49,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{CC82CD9F
 		build.fsx = build.fsx
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmark", "benchmark", "{7B7D8B0C-110F-4120-85A9-D0F9A9A97448}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Helios.Benchmark.DedicatedThreadFiber", "benchmark\Helios.Benchmark.DedicatedThreadFiber\Helios.Benchmark.DedicatedThreadFiber.csproj", "{8157DE3E-526D-47C2-A6FB-AD24AD873EFF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -107,6 +111,10 @@ Global
 		{9435B7DF-A2CB-4CA4-945C-B7E663019ACE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9435B7DF-A2CB-4CA4-945C-B7E663019ACE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9435B7DF-A2CB-4CA4-945C-B7E663019ACE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8157DE3E-526D-47C2-A6FB-AD24AD873EFF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8157DE3E-526D-47C2-A6FB-AD24AD873EFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8157DE3E-526D-47C2-A6FB-AD24AD873EFF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8157DE3E-526D-47C2-A6FB-AD24AD873EFF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -126,5 +134,6 @@ Global
 		{B4483775-BF67-4963-8A12-70145DA3136D} = {CDCC7F36-83CF-430B-86CF-46CDF610301F}
 		{4F89F69D-F12C-4754-BAB8-67582908F7DE} = {CDCC7F36-83CF-430B-86CF-46CDF610301F}
 		{9435B7DF-A2CB-4CA4-945C-B7E663019ACE} = {5E5EEA56-0AA6-469A-8123-E3076881057D}
+		{8157DE3E-526D-47C2-A6FB-AD24AD873EFF} = {7B7D8B0C-110F-4120-85A9-D0F9A9A97448}
 	EndGlobalSection
 EndGlobal

--- a/benchmark/Helios.Benchmark.DedicatedThreadFiber/App.config
+++ b/benchmark/Helios.Benchmark.DedicatedThreadFiber/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/benchmark/Helios.Benchmark.DedicatedThreadFiber/Helios.Benchmark.DedicatedThreadFiber.csproj
+++ b/benchmark/Helios.Benchmark.DedicatedThreadFiber/Helios.Benchmark.DedicatedThreadFiber.csproj
@@ -1,0 +1,64 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8157DE3E-526D-47C2-A6FB-AD24AD873EFF}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Helios.Benchmark.DedicatedThreadFiber</RootNamespace>
+    <AssemblyName>Helios.Benchmark.DedicatedThreadFiber</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Helios\Helios.csproj">
+      <Project>{fcc26fa6-1b8e-413d-aca5-a25b9c6459a1}</Project>
+      <Name>Helios</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/benchmark/Helios.Benchmark.DedicatedThreadFiber/Program.cs
+++ b/benchmark/Helios.Benchmark.DedicatedThreadFiber/Program.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Diagnostics;
+using Helios.Concurrency;
+
+namespace Helios.Benchmark.DedicatedThreadFiber
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var generations = 4;
+            var threadCount = Environment.ProcessorCount;
+            for (int i = 0; i < generations; i++)
+            {
+                var workItems = 10000 * (int)Math.Pow(10, i);
+                Console.WriteLine("Comparing Helios.Concurrency.DedicatedThreadPool vs Helios.Concurrency.DedicatedThreadFiber for {0} items", workItems);
+                Console.WriteLine("DedicatedThreadFiber.NumThreads: {0}", threadCount);
+
+                Console.WriteLine("System.Threading.ThreadPool");
+                Console.WriteLine(
+                    TimeSpan.FromMilliseconds(
+                        Enumerable.Range(0, 6).Select(_ =>
+                        {
+                            var sw = Stopwatch.StartNew();
+                            CreateAndWaitForWorkItems(workItems);
+                            return sw.ElapsedMilliseconds;
+                        }).Skip(1).Average()
+                    )
+                );
+
+                Console.WriteLine("Helios.Concurrency.DedicatedThreadFiber");
+                Console.WriteLine(
+                    TimeSpan.FromMilliseconds(
+                        Enumerable.Range(0, 6).Select(_ =>
+                        {
+                            var sw = Stopwatch.StartNew();
+                            CreateAndWaitForWorkItems(workItems, threadCount);
+                            return sw.ElapsedMilliseconds;
+                        }).Skip(1).Average()
+                    )
+                );
+            }
+           
+        }
+
+        static void CreateAndWaitForWorkItems(int numWorkItems)
+        {
+            using (ManualResetEvent mre = new ManualResetEvent(false))
+            {
+                int itemsRemaining = numWorkItems;
+                for (int i = 0; i < numWorkItems; i++)
+                {
+                    ThreadPool.QueueUserWorkItem(delegate
+                    {
+                        if (Interlocked.Decrement(
+                            ref itemsRemaining) == 0) mre.Set();
+                    });
+                }
+                mre.WaitOne();
+            }
+        }
+
+        static void CreateAndWaitForWorkItems(int numWorkItems, int numThreads)
+        {
+            using (ManualResetEvent mre = new ManualResetEvent(false))
+            using (var fiber = FiberFactory.CreateFiber(numThreads))
+            {
+                int itemsRemaining = numWorkItems;
+                for (int i = 0; i < numWorkItems; i++)
+                {
+                    fiber.Add(delegate
+                    {
+                        if (Interlocked.Decrement(
+                            ref itemsRemaining) == 0) mre.Set();
+                    });
+                }
+                mre.WaitOne();
+            }
+        }
+    }
+}

--- a/benchmark/Helios.Benchmark.DedicatedThreadFiber/Properties/AssemblyInfo.cs
+++ b/benchmark/Helios.Benchmark.DedicatedThreadFiber/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Helios.Benchmark.DedicatedThreadFiber")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Helios.Benchmark.DedicatedThreadFiber")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("c4a25046-f1b1-4255-9ffb-8e548e2c9402")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Helios/Concurrency/Impl/DedicatedThreadPoolFiber.cs
+++ b/src/Helios/Concurrency/Impl/DedicatedThreadPoolFiber.cs
@@ -15,7 +15,7 @@ namespace Helios.Concurrency.Impl
         private readonly int _numThreads;
         private List<Thread> _threads;
 
-        private readonly BlockingCollection<Action> _blockingCollection = new BlockingCollection<Action>(25000);
+        private readonly BlockingCollection<Action> _blockingCollection = new BlockingCollection<Action>(250000);
 
         public DedicatedThreadPoolFiber(int numThreads)
             : this(new BasicExecutor(), numThreads)


### PR DESCRIPTION
upped the size of the DedicatedThreadPoolFiber queue by 10x and added a benchmark to compare its performance against the traditional CLR thread pool.

On my machine (Asus g70 gaming laptop - 4 core I7 2.4ghz) I received the following results:

Comparing Helios.Concurrency.DedicatedThreadPool vs Helios.Concurrency.DedicatedThreadFiber for 10000 items
DedicatedThreadFiber.NumThreads: 8
System.Threading.ThreadPool
00:00:00.0040000
Helios.Concurrency.DedicatedThreadFiber
00:00:00.0140000
Comparing Helios.Concurrency.DedicatedThreadPool vs Helios.Concurrency.DedicatedThreadFiber for 100000 items
DedicatedThreadFiber.NumThreads: 8
System.Threading.ThreadPool
00:00:00.0460000
Helios.Concurrency.DedicatedThreadFiber
00:00:00.1990000
Comparing Helios.Concurrency.DedicatedThreadPool vs Helios.Concurrency.DedicatedThreadFiber for 1000000 items
DedicatedThreadFiber.NumThreads: 8
System.Threading.ThreadPool
00:00:00.3950000
Helios.Concurrency.DedicatedThreadFiber
00:00:01.8900000
Comparing Helios.Concurrency.DedicatedThreadPool vs Helios.Concurrency.DedicatedThreadFiber for 10000000 items
DedicatedThreadFiber.NumThreads: 8
System.Threading.ThreadPool
00:00:03.6120000
Helios.Concurrency.DedicatedThreadFiber
00:00:23.0930000