### PR TITLE
all writes now block

### DIFF
--- a/src/Helios/Reactor/Response/TcpReactorResponseChannel.cs
+++ b/src/Helios/Reactor/Response/TcpReactorResponseChannel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using Helios.Buffers;
+using Helios.Concurrency;
 using Helios.Net;
 using Helios.Topology;
 using Helios.Tracing;
@@ -44,7 +45,7 @@ namespace Helios.Reactor.Response
         public override void Send(NetworkData data)
         {
 			HeliosTrace.Instance.TcpInboundSendQueued ();
-			EventLoop.Execute (() => SendInternal (data.Buffer, 0, data.Length, data.RemoteHost));
+			SendInternal (data.Buffer, 0, data.Length, data.RemoteHost);
         }
 
         private void SendInternal(byte[] buffer, int index, int length, INode remoteHost)


### PR DESCRIPTION
Made a big performance trade-off here in the name of safety and reliability.

TL;DR; - our previous code for asynchronously batching writes worked great much of the time and was very performant, but was subject to race conditions that could cause messages queued for delivery to never be sent. This issue occurred for two reasons: 1. We used a really small fixed size circular buffer that would truncate (that's what I fixed yesterday) old messages and 2. our batching code had a *known* race condition that could cause some messages to never be delivered in the event that a client suddenly stopped writing to a socket (we're talking microsecond pauses.)

I care way more about reliability than performance, so for the time being all Helios writes are going to be synchronous. I've written [ad nauseum about why this (synchronous socket writes) is generally a good idea and backed it up with data](http://www.aaronstannard.com/tradeoffs-in-high-performance-software/) before, so it shouldn't be of surprise to anyone.

At extremely high write volumes (1 million messages per second per client) this will cause a noticeable slowdown, although not realistically worse than what would happen in the previous implementation.

With this, v1.4 should now be considered finished. Going to do some more Mono tests today and then sign off on the build tonight hopefully.