### PR TITLE
removed NuGet publish key from build logs

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -258,7 +258,7 @@ let publishNugetPackages _ =
                     info.WorkingDirectory <- (Path.GetDirectoryName (FullName packageFile))
                     info.Arguments <- args (packageFile, accessKey,url)) (System.TimeSpan.FromMinutes 1.0)
             enableProcessTracing <- tracing
-            if result <> 0 then failwithf "Error during NuGet symbol push. %s %s" nugetExe (args (packageFile, accessKey,url))
+            if result <> 0 then failwithf "Error during NuGet symbol push. %s %s" nugetExe (args (packageFile, "key omitted",url))
         with exn -> 
             if (trialsLeft > 0) then (publishPackage url accessKey (trialsLeft-1) packageFile)
             else raise exn


### PR DESCRIPTION
To make it safe to do nightlies and release builds on publicly-visible projects