### PR TITLE
Attempt to support IPv6 addresses

### DIFF
--- a/src/Helios/Net/Connections/TcpConnection.cs
+++ b/src/Helios/Net/Connections/TcpConnection.cs
@@ -349,7 +349,7 @@ namespace Helios.Net.Connections
 
         private void InitClient()
         {
-            _client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp)
+            _client = new Socket(Binding.Host.AddressFamily, SocketType.Stream, ProtocolType.Tcp)
             {
                 ReceiveTimeout = Timeout.Seconds,
                 SendTimeout = Timeout.Seconds,

--- a/src/Helios/Net/Connections/UdpConnection.cs
+++ b/src/Helios/Net/Connections/UdpConnection.cs
@@ -272,7 +272,7 @@ namespace Helios.Net.Connections
 
         protected void InitClient()
         {
-            Client = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)
+            Client = new Socket(Binding.Host.AddressFamily, SocketType.Dgram, ProtocolType.Udp)
             {
                 MulticastLoopback = false
             };

--- a/src/Helios/Reactor/ReactorBase.cs
+++ b/src/Helios/Reactor/ReactorBase.cs
@@ -30,7 +30,7 @@ namespace Helios.Reactor
             Encoder = encoder;
             Allocator = allocator;
             LocalEndpoint = new IPEndPoint(localAddress, localPort);
-            Listener = new Socket(AddressFamily.InterNetwork, socketType, protocol);
+            Listener = new Socket(LocalEndpoint.AddressFamily, socketType, protocol);
             if (protocol == ProtocolType.Tcp)
             {
                 Transport = TransportType.Tcp;

--- a/src/Helios/Reactor/Tcp/TcpProxyReactor.cs
+++ b/src/Helios/Reactor/Tcp/TcpProxyReactor.cs
@@ -33,7 +33,7 @@ namespace Helios.Reactor.Tcp
                 bufferSize)
         {
             LocalEndpoint = new IPEndPoint(localAddress, localPort);
-            Listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            Listener = new Socket(LocalEndpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
         }
 
         public override bool IsActive { get; protected set; }

--- a/src/Helios/Topology/NodeBuilder.cs
+++ b/src/Helios/Topology/NodeBuilder.cs
@@ -48,8 +48,11 @@ namespace Helios.Topology
             if (!IPAddress.TryParse(host, out parseIp))
             {
                 var hostentry = Dns.GetHostEntry(host);
-                parseIp = hostentry.AddressList.First(x => x.AddressFamily == AddressFamily.InterNetwork);
-                    //first IPv4 address
+                parseIp = hostentry.AddressList.FirstOrDefault(x => x.AddressFamily == AddressFamily.InterNetwork); // first IPv4 address
+                if (parseIp == null)
+                {
+                    parseIp = hostentry.AddressList.First(x => x.AddressFamily == AddressFamily.InterNetworkV6); // first IPv6 address
+                }
             }
 
             return Host(n, parseIp);

--- a/src/Helios/Topology/NodeUri.cs
+++ b/src/Helios/Topology/NodeUri.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Net;
+using System.Net.Sockets;
 using System.Runtime.Serialization;
 using Helios.Util;
 
@@ -33,7 +34,7 @@ namespace Helios.Topology
         public static string GetUriStringForNode(INode node)
         {
             if (node.IsEmpty()) return string.Empty;
-            return string.Format("{0}://{1}:{2}", GetProtocolStringForTransportType(node.TransportType), node.Host,
+            return string.Format("{0}://{1}:{2}", GetProtocolStringForTransportType(node.TransportType), GetHostStringForAddress(node.Host),
                 node.Port);
         }
 
@@ -48,6 +49,16 @@ namespace Helios.Topology
                 default:
                     return "socket";
             }
+        }
+
+        public static string GetHostStringForAddress(IPAddress address)
+        {
+            var host = address.ToString();
+            if (address.AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                host = string.Format("[{0}]", host);
+            }
+            return host;
         }
 
 #if !NET35 && !NET40

--- a/tests/Helios.Tests/Net/TcpConnectionTests.cs
+++ b/tests/Helios.Tests/Net/TcpConnectionTests.cs
@@ -37,6 +37,28 @@ namespace Helios.Tests.Net
             Assert.True(boolDisconnected);
         }
 
+        [Fact]
+        public void Should_not_throw_exception_when_connecting_via_ipv6()
+        {
+            // arrange
+            var node = NodeBuilder.BuildNode().Host(IPAddress.IPv6Loopback).WithPort(11111);
+            var connection = node.GetConnection();
+            var boolDisconnected = false;
+            var resetEvent = new AutoResetEvent(false);
+            connection.OnDisconnection += delegate
+            {
+                boolDisconnected = true;
+                resetEvent.Set();
+            };
+
+            // act
+            connection.Open();
+            resetEvent.WaitOne();
+
+            // assert
+            Assert.True(boolDisconnected);
+        }
+
         #endregion
 
         #region Setup / Teardown

--- a/tests/Helios.Tests/Topology/NodeUriTests.cs
+++ b/tests/Helios.Tests/Topology/NodeUriTests.cs
@@ -35,6 +35,23 @@ namespace Helios.Tests.Topology
         }
 
         [Fact]
+        public void Should_convert_valid_ipv6_tcp_INode_to_NodeUri()
+        {
+            //arrange
+            var testNode =
+                NodeBuilder.BuildNode().Host(IPAddress.IPv6Loopback).WithPort(1337).WithTransportType(TransportType.Tcp);
+
+            //act
+            var nodeUri = new NodeUri(testNode);
+
+            //assert
+            Assert.Equal(testNode.Port, nodeUri.Port);
+            Assert.Equal(string.Format("[{0}]", testNode.Host), nodeUri.Host);
+            Assert.Equal("tcp", nodeUri.Scheme);
+            Assert.True(nodeUri.IsLoopback);
+        }
+
+        [Fact]
         public void Should_convert_valid_tcp_NodeUri_to_INode()
         {
             //arrange


### PR DESCRIPTION
Uses the `AddressFamily` property of the `IPAddress` in the creation of the socket. This allows for supporting IPv6 addresses.