### PR TITLE
Helios 2.1 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 2.0.2 May 6 2016
+* Added DNS support to `ServerBootstrap` so hostnames can be bound.
+
 #### 2.0.1 May 6 2016
 * Added `MessageToMessageDecoder<T>` base class to Helios.Codecs
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,33 @@
 #### 2.1.0 May 16 2016
-Placeholder for next major perf upgrade
+* Added support for batch writes
+* Made write objects reusable
+* IPv6 support for legacy API
+
+Net performance impact of above changes as reported by build server:
+
+**Before**
+
+          Metric |           Units |             Max |         Average |             Min |          StdDev |
+---------------- |---------------- |---------------- |---------------- |---------------- |---------------- |
+TotalCollections [Gen0] |     collections / s |           40.14 |           40.14 |           40.14 |            0.00 |
+TotalCollections [Gen1] |     collections / s |            2.86 |            2.86 |            2.86 |            0.00 |
+TotalCollections [Gen2] |     collections / s |            0.53 |            0.53 |            0.53 |            0.00 |
+TotalBytesAllocated |           bytes / s |      293,950.63 |      293,950.63 |      293,950.63 |            0.00 |
+[Counter] inbound ops |      operations / s |       55,782.90 |       55,782.90 |       55,782.90 |            0.00 |
+[Counter] outbound ops |      operations / |       55,783.07 |       55,783.07 |       55,783.07 |            0.00 |
+Max concurrent connections |      operations |          440.00 |          440.00 |          440.00 |            0.00 |
+
+**After**
+
+          Metric |           Units |             Max |         Average |             Min |          StdDev |
+---------------- |---------------- |---------------- |---------------- |---------------- |---------------- |
+TotalCollections [Gen0] |     collections |           26.41 |           26.41 |           26.41 |            0.00 |
+TotalCollections [Gen1] |     collections |            8.33 |            8.33 |            8.33 |            0.00 |
+TotalCollections [Gen2] |     collections |            0.08 |            0.08 |            0.08 |            0.00 |
+TotalBytesAllocated |           bytes |       38,170.63 |       38,170.63 |       38,170.63 |            0.00 |
+[Counter] inbound ops |      operations |       99,728.63 |       99,728.63 |       99,728.63 |            0.00 |
+[Counter] outbound ops |      operations |       99,728.67 |       99,728.67 |       99,728.67 |            0.00 |
+Max concurrent connections |      operations |          945.00 |          945.00 |          945.00 |            0.00 | 
 
 #### 2.0.2 May 6 2016
 * Added DNS support to `ServerBootstrap` so hostnames can be bound.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 2.1.0 May 16 2016
+Placeholder for next major perf upgrade
+
 #### 2.0.2 May 6 2016
 * Added DNS support to `ServerBootstrap` so hostnames can be bound.
 

--- a/src/Helios/Buffers/AbstractByteBuf.cs
+++ b/src/Helios/Buffers/AbstractByteBuf.cs
@@ -628,6 +628,16 @@ namespace Helios.Buffers
             return this;
         }
 
+        public abstract int IoBufferCount { get; }
+
+        public ArraySegment<byte> GetIoBuffer() => GetIoBuffer(this.ReaderIndex, this.ReadableBytes);
+
+        public abstract ArraySegment<byte> GetIoBuffer(int index, int length);
+
+        public ArraySegment<byte>[] GetIoBuffers() => GetIoBuffers(this.ReaderIndex, this.ReadableBytes);
+
+        public abstract ArraySegment<byte>[] GetIoBuffers(int index, int length);
+
         public IByteBuf WriteZero(int length)
         {
             if (length == 0)

--- a/src/Helios/Buffers/AbstractDerivedByteBuffer.cs
+++ b/src/Helios/Buffers/AbstractDerivedByteBuffer.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 // See ThirdPartyNotices.txt for references to third party code used inside Helios.
 
+using System;
+
 namespace Helios.Buffers
 {
     /// <summary>
@@ -45,6 +47,8 @@ namespace Helios.Buffers
         {
             return Unwrap().Release(decrement);
         }
+
+        public override ArraySegment<byte> GetIoBuffer(int index, int length) => Unwrap().GetIoBuffer(index, length);
     }
 }
 

--- a/src/Helios/Buffers/DuplicateByteBuf.cs
+++ b/src/Helios/Buffers/DuplicateByteBuf.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 // See ThirdPartyNotices.txt for references to third party code used inside Helios.
 
+using System;
+
 namespace Helios.Buffers
 {
     /// <summary>
@@ -180,6 +182,10 @@ namespace Helios.Buffers
         {
             return _buffer;
         }
+
+        public override int IoBufferCount => Unwrap().IoBufferCount;
+
+        public override ArraySegment<byte>[] GetIoBuffers(int index, int length) => Unwrap().GetIoBuffers(index, length);
 
         public override IByteBuf Compact()
         {

--- a/src/Helios/Buffers/EmptyByteBuf.cs
+++ b/src/Helios/Buffers/EmptyByteBuf.cs
@@ -3,6 +3,7 @@
 // See ThirdPartyNotices.txt for references to third party code used inside Helios.
 
 using System;
+using Helios.Util;
 
 namespace Helios.Buffers
 {
@@ -11,6 +12,9 @@ namespace Helios.Buffers
     /// </summary>
     public class EmptyByteBuf : AbstractByteBuf
     {
+        static readonly ArraySegment<byte> EmptyBuffer = new ArraySegment<byte>(ByteArrayExtensions.Empty);
+        static readonly ArraySegment<byte>[] EmptyBuffers = { EmptyBuffer };
+
         public EmptyByteBuf(IByteBufAllocator allocator) : base(0)
         {
             Allocator = allocator;
@@ -45,6 +49,20 @@ namespace Helios.Buffers
         public override int ReferenceCount
         {
             get { return 1; }
+        }
+
+        public override int IoBufferCount => 1;
+
+        public override ArraySegment<byte> GetIoBuffer(int index, int length)
+        {
+            CheckIndex(index, length);
+            return EmptyBuffer;
+        }
+
+        public override ArraySegment<byte>[] GetIoBuffers(int index, int length)
+        {
+            CheckIndex(index, length);
+            return GetIoBuffers();
         }
 
         public override IByteBuf AdjustCapacity(int newCapacity)

--- a/src/Helios/Buffers/IByteBuf.cs
+++ b/src/Helios/Buffers/IByteBuf.cs
@@ -598,6 +598,90 @@ namespace Helios.Buffers
 
         IByteBuf WriteBytes(byte[] src, int srcIndex, int length);
 
+        /// <summary>
+        ///     Returns the maximum <see cref="ArraySegment{T}" /> of <see cref="Byte" /> that this buffer holds. Note that
+        ///     <see cref="GetIoBuffers()" />
+        ///     or <see cref="GetIoBuffers(int,int)" /> might return a less number of <see cref="ArraySegment{T}" />s of
+        ///     <see cref="Byte" />.
+        /// </summary>
+        /// <returns>
+        ///     <c>-1</c> if this buffer cannot represent its content as <see cref="ArraySegment{T}" /> of <see cref="Byte" />.
+        ///     the number of the underlying {@link ByteBuffer}s if this buffer has at least one underlying segment.
+        ///     Note that this method does not return <c>0</c> to avoid confusion.
+        /// </returns>
+        /// <seealso cref="GetIoBuffer()" />
+        /// <seealso cref="GetIoBuffer(int,int)" />
+        /// <seealso cref="GetIoBuffers()" />
+        /// <seealso cref="GetIoBuffers(int,int)" />
+        int IoBufferCount { get; }
+
+        /// <summary>
+        ///     Exposes this buffer's readable bytes as an <see cref="ArraySegment{T}" /> of <see cref="Byte" />. Returned segment
+        ///     shares the content with this buffer. This method is identical
+        ///     to <c>buf.GetIoBuffer(buf.ReaderIndex, buf.ReadableBytes)</c>. This method does not
+        ///     modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.  Please note that the
+        ///     returned segment will not see the changes of this buffer if this buffer is a dynamic
+        ///     buffer and it adjusted its capacity.
+        /// </summary>
+        /// <exception cref="NotSupportedException">
+        ///     if this buffer cannot represent its content as <see cref="ArraySegment{T}" />
+        ///     of <see cref="Byte" />
+        /// </exception>
+        /// <seealso cref="IoBufferCount" />
+        /// <seealso cref="GetIoBuffers()" />
+        /// <seealso cref="GetIoBuffers(int,int)" />
+        ArraySegment<byte> GetIoBuffer();
+
+        /// <summary>
+        ///     Exposes this buffer's sub-region as an <see cref="ArraySegment{T}" /> of <see cref="Byte" />. Returned segment
+        ///     shares the content with this buffer. This method does not
+        ///     modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer. Please note that the
+        ///     returned segment will not see the changes of this buffer if this buffer is a dynamic
+        ///     buffer and it adjusted its capacity.
+        /// </summary>
+        /// <exception cref="NotSupportedException">
+        ///     if this buffer cannot represent its content as <see cref="ArraySegment{T}" />
+        ///     of <see cref="Byte" />
+        /// </exception>
+        /// <seealso cref="IoBufferCount" />
+        /// <seealso cref="GetIoBuffers()" />
+        /// <seealso cref="GetIoBuffers(int,int)" />
+        ArraySegment<byte> GetIoBuffer(int index, int length);
+
+        /// <summary>
+        ///     Exposes this buffer's readable bytes as an array of <see cref="ArraySegment{T}" /> of <see cref="Byte" />. Returned
+        ///     segments
+        ///     share the content with this buffer. This method does not
+        ///     modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.  Please note that
+        ///     returned segments will not see the changes of this buffer if this buffer is a dynamic
+        ///     buffer and it adjusted its capacity.
+        /// </summary>
+        /// <exception cref="NotSupportedException">
+        ///     if this buffer cannot represent its content with <see cref="ArraySegment{T}" />
+        ///     of <see cref="Byte" />
+        /// </exception>
+        /// <seealso cref="IoBufferCount" />
+        /// <seealso cref="GetIoBuffer()" />
+        /// <seealso cref="GetIoBuffer(int,int)" />
+        ArraySegment<byte>[] GetIoBuffers();
+
+        /// <summary>
+        ///     Exposes this buffer's bytes as an array of <see cref="ArraySegment{T}" /> of <see cref="Byte" /> for the specified
+        ///     index and length.
+        ///     Returned segments share the content with this buffer. This method does
+        ///     not modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer. Please note that
+        ///     returned segments will not see the changes of this buffer if this buffer is a dynamic
+        ///     buffer and it adjusted its capacity.
+        /// </summary>
+        /// <exception cref="NotSupportedException">
+        ///     if this buffer cannot represent its content with <see cref="ArraySegment{T}" />
+        ///     of <see cref="Byte" />
+        /// </exception>
+        /// <seealso cref="IoBufferCount" />
+        /// <seealso cref="GetIoBuffer()" />
+        /// <seealso cref="GetIoBuffer(int,int)" />
+        ArraySegment<byte>[] GetIoBuffers(int index, int length);
+
         IByteBuf WriteZero(int length);
 
         /// <summary>

--- a/src/Helios/Buffers/SlicedByteBuffer.cs
+++ b/src/Helios/Buffers/SlicedByteBuffer.cs
@@ -8,9 +8,9 @@ namespace Helios.Buffers
 {
     public sealed class SlicedByteBuffer : AbstractDerivedByteBuffer
     {
-        private readonly int adjustment;
-        private readonly IByteBuf buffer;
-        private readonly int length;
+        private readonly int _adjustment;
+        private readonly IByteBuf _buffer;
+        private readonly int _length;
 
         public SlicedByteBuffer(IByteBuf buffer, int index, int length)
             : base(length)
@@ -23,59 +23,73 @@ namespace Helios.Buffers
             var slicedByteBuf = buffer as SlicedByteBuffer;
             if (slicedByteBuf != null)
             {
-                this.buffer = slicedByteBuf.buffer;
-                adjustment = slicedByteBuf.adjustment + index;
+                this._buffer = slicedByteBuf._buffer;
+                _adjustment = slicedByteBuf._adjustment + index;
             }
             else if (buffer is DuplicateByteBuf)
             {
-                this.buffer = buffer.Unwrap();
-                adjustment = index;
+                this._buffer = buffer.Unwrap();
+                _adjustment = index;
             }
             else
             {
-                this.buffer = buffer;
-                adjustment = index;
+                this._buffer = buffer;
+                _adjustment = index;
             }
-            this.length = length;
+            this._length = length;
 
             SetWriterIndex(length);
         }
 
         public override IByteBufAllocator Allocator
         {
-            get { return buffer.Allocator; }
+            get { return _buffer.Allocator; }
         }
 
         public override ByteOrder Order
         {
-            get { return buffer.Order; }
+            get { return _buffer.Order; }
         }
 
         public override int Capacity
         {
-            get { return length; }
+            get { return _length; }
+        }
+
+        public override int IoBufferCount => this.Unwrap().IoBufferCount;
+
+        public override ArraySegment<byte> GetIoBuffer(int index, int length)
+        {
+            this.CheckIndex(index, length);
+            return this.Unwrap().GetIoBuffer(index + this._adjustment, length);
+        }
+
+        public override ArraySegment<byte>[] GetIoBuffers(int index, int length)
+        {
+            this.CheckIndex(index, length);
+            return this.Unwrap().GetIoBuffers(index + this._adjustment, length);
         }
 
         public override bool HasArray
         {
-            get { return buffer.HasArray; }
+            get { return _buffer.HasArray; }
         }
 
         public override byte[] Array
         {
-            get { return buffer.Array; }
+            get { return _buffer.Array; }
         }
 
-        public override bool IsDirect => buffer.IsDirect;
+        public override bool IsDirect => _buffer.IsDirect;
 
         public override int ArrayOffset
         {
-            get { return buffer.ArrayOffset + adjustment; }
+            get { return _buffer.ArrayOffset + _adjustment; }
         }
 
         public override IByteBuf Unwrap()
         {
-            return buffer;
+            return _buffer;
         }
 
         public override IByteBuf Compact()
@@ -95,27 +109,27 @@ namespace Helios.Buffers
 
         protected override byte _GetByte(int index)
         {
-            return buffer.GetByte(index + adjustment);
+            return _buffer.GetByte(index + _adjustment);
         }
 
         protected override short _GetShort(int index)
         {
-            return buffer.GetShort(index + adjustment);
+            return _buffer.GetShort(index + _adjustment);
         }
 
         protected override int _GetInt(int index)
         {
-            return buffer.GetInt(index + adjustment);
+            return _buffer.GetInt(index + _adjustment);
         }
 
         protected override long _GetLong(int index)
         {
-            return buffer.GetLong(index + adjustment);
+            return _buffer.GetLong(index + _adjustment);
         }
 
         public override IByteBuf Duplicate()
         {
-            var duplicate = buffer.Slice(adjustment, length);
+            var duplicate = _buffer.Slice(_adjustment, _length);
             duplicate.SetIndex(ReaderIndex, WriterIndex);
             return duplicate;
         }
@@ -129,7 +143,7 @@ namespace Helios.Buffers
         public override IByteBuf Copy(int index, int length)
         {
             CheckIndex(index, length);
-            return buffer.Copy(index + adjustment, length);
+            return _buffer.Copy(index + _adjustment, length);
         }
 
         public override IByteBuf Slice(int index, int length)
@@ -139,54 +153,54 @@ namespace Helios.Buffers
             {
                 return Unpooled.Empty;
             }
-            return buffer.Slice(index + adjustment, length);
+            return _buffer.Slice(index + _adjustment, length);
         }
 
         public override IByteBuf GetBytes(int index, IByteBuf dst, int dstIndex, int length)
         {
             CheckIndex(index, length);
-            buffer.GetBytes(index + adjustment, dst, dstIndex, length);
+            _buffer.GetBytes(index + _adjustment, dst, dstIndex, length);
             return this;
         }
 
         public override IByteBuf GetBytes(int index, byte[] dst, int dstIndex, int length)
         {
             CheckIndex(index, length);
-            buffer.GetBytes(index + adjustment, dst, dstIndex, length);
+            _buffer.GetBytes(index + _adjustment, dst, dstIndex, length);
             return this;
         }
 
         protected override IByteBuf _SetByte(int index, int value)
         {
-            return buffer.SetByte(index + adjustment, value);
+            return _buffer.SetByte(index + _adjustment, value);
         }
 
         protected override IByteBuf _SetShort(int index, int value)
         {
-            return buffer.SetShort(index + adjustment, value);
+            return _buffer.SetShort(index + _adjustment, value);
         }
 
         protected override IByteBuf _SetInt(int index, int value)
         {
-            return buffer.SetInt(index + adjustment, value);
+            return _buffer.SetInt(index + _adjustment, value);
         }
 
         protected override IByteBuf _SetLong(int index, long value)
         {
-            return buffer.SetLong(index + adjustment, value);
+            return _buffer.SetLong(index + _adjustment, value);
         }
 
         public override IByteBuf SetBytes(int index, byte[] src, int srcIndex, int length)
         {
             CheckIndex(index, length);
-            buffer.SetBytes(index + adjustment, src, srcIndex, length);
+            _buffer.SetBytes(index + _adjustment, src, srcIndex, length);
             return this;
         }
 
         public override IByteBuf SetBytes(int index, IByteBuf src, int srcIndex, int length)
         {
             CheckIndex(index, length);
-            buffer.SetBytes(index + adjustment, src, srcIndex, length);
+            _buffer.SetBytes(index + _adjustment, src, srcIndex, length);
             return this;
         }
     }

--- a/src/Helios/Buffers/SwappedByteBuffer.cs
+++ b/src/Helios/Buffers/SwappedByteBuffer.cs
@@ -73,6 +73,16 @@ namespace Helios.Buffers
             return this;
         }
 
+        public int IoBufferCount => this._buf.IoBufferCount;
+
+        public ArraySegment<byte> GetIoBuffer() => this._buf.GetIoBuffer();
+
+        public ArraySegment<byte> GetIoBuffer(int index, int length) => this._buf.GetIoBuffer(index, length);
+
+        public ArraySegment<byte>[] GetIoBuffers() => this._buf.GetIoBuffers();
+
+        public ArraySegment<byte>[] GetIoBuffers(int index, int length) => this._buf.GetIoBuffers(index, length);
+
         public int ReadableBytes
         {
             get { return _buf.ReadableBytes; }

--- a/src/Helios/Buffers/UnpooledDirectByteBuf.cs
+++ b/src/Helios/Buffers/UnpooledDirectByteBuf.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 // See ThirdPartyNotices.txt for references to third party code used inside Helios.
 
+using System;
 using System.Diagnostics.Contracts;
 
 namespace Helios.Buffers
@@ -228,6 +229,16 @@ namespace Helios.Buffers
             System.Array.Copy(_buffer, index, copiedArray, 0, length);
             return new UnpooledDirectByteBuf(Allocator, copiedArray, MaxCapacity);
         }
+
+        public override int IoBufferCount => 1;
+
+        public override ArraySegment<byte> GetIoBuffer(int index, int length)
+        {
+            this.EnsureAccessible();
+            return new ArraySegment<byte>(_buffer, index, length);
+        }
+
+        public override ArraySegment<byte>[] GetIoBuffers(int index, int length) => new[] { this.GetIoBuffer(index, length) };
 
         public override IByteBuf Unwrap()
         {

--- a/src/Helios/Channels/ChannelOutboundBuffer.cs
+++ b/src/Helios/Channels/ChannelOutboundBuffer.cs
@@ -3,6 +3,8 @@
 // See ThirdPartyNotices.txt for references to third party code used inside Helios.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 using System.Threading;
 using Helios.Buffers;
 using Helios.Concurrency;
@@ -19,6 +21,7 @@ namespace Helios.Channels
     public sealed class ChannelOutboundBuffer
     {
         private static readonly ILogger Logger = LoggingFactory.GetLogger<ChannelOutboundBuffer>();
+        private static readonly ThreadLocalByteBufferList NioBuffers = new ThreadLocalByteBufferList();
 
         /// <summary>
         ///     Callback used to indicate that the channel is going to become writeable or unwriteable
@@ -121,7 +124,7 @@ namespace Helios.Channels
         /// <param name="promise">A <see cref="TaskCompletionSource" /> that will be set once message was written.</param>
         public void AddMessage(object message, int size, TaskCompletionSource promise)
         {
-            var entry = Entry.NewInstance(message, size, Total(message), promise);
+            var entry = Entry.NewInstance(message, size, promise);
             if (_tailEntry == null)
             {
                 _flushedEntry = null;
@@ -373,6 +376,143 @@ namespace Helios.Channels
         }
 
         /// <summary>
+        ///     Removes the fully written entries and update the reader index of the partially written entry.
+        ///     This operation assumes all messages in this buffer is {@link ByteBuf}.
+        /// </summary>
+        public void RemoveBytes(long writtenBytes)
+        {
+            while (true)
+            {
+                object msg = this.Current;
+                if (!(msg is IByteBuf))
+                {
+                    Contract.Assert(writtenBytes == 0);
+                    break;
+                }
+
+                var buf = (IByteBuf)msg;
+                int readerIndex = buf.ReaderIndex;
+                int readableBytes = buf.WriterIndex - readerIndex;
+
+                if (readableBytes <= writtenBytes)
+                {
+                    if (writtenBytes != 0)
+                    {
+                        writtenBytes -= readableBytes;
+                    }
+                    this.Remove();
+                }
+                else
+                {
+                    // readableBytes > writtenBytes
+                    if (writtenBytes != 0)
+                    {
+                        buf.SetReaderIndex(readerIndex + (int)writtenBytes);
+                    }
+                    break;
+                }
+            }
+            this.ClearNioBuffers();
+        }
+
+        private void ClearNioBuffers() => NioBuffers.Value.Clear();
+
+        ///
+        ///Returns an array of direct NIO buffers if the currently pending messages are made of {@link ByteBuf} only.
+        ///{@link #nioBufferCount()} and {@link #nioBufferSize()} will return the number of NIO buffers in the returned
+        ///array and the total number of readable bytes of the NIO buffers respectively.
+        ///<p>
+        ///Note that the returned array is reused and thus should not escape
+        ///{@link AbstractChannel#doWrite(ChannelOutboundBuffer)}.
+        ///Refer to {@link NioSocketChannel#doWrite(ChannelOutboundBuffer)} for an example.
+        ///</p>
+        ///
+        public List<ArraySegment<byte>> GetNioBuffers()
+        {
+            long nioBufferSize = 0;
+            InternalThreadLocalMap threadLocalMap = InternalThreadLocalMap.Get();
+            List<ArraySegment<byte>> nioBuffers = NioBuffers.Get(threadLocalMap);
+            Entry entry = _flushedEntry;
+            while (IsFlushedEntry(entry) && entry.Message is IByteBuf)
+            {
+                if (!entry.Cancelled)
+                {
+                    var buf = (IByteBuf)entry.Message;
+                    int readerIndex = buf.ReaderIndex;
+                    int readableBytes = buf.WriterIndex - readerIndex;
+
+                    if (readableBytes > 0)
+                    {
+                        if (int.MaxValue - readableBytes < nioBufferSize)
+                        {
+                            // If the nioBufferSize + readableBytes will overflow an Integer we stop populate the
+                            // ByteBuffer array. This is done as bsd/osx don't allow to write more bytes then
+                            // Integer.MAX_VALUE with one writev(...) call and so will return 'EINVAL', which will
+                            // raise an IOException. On Linux it may work depending on the
+                            // architecture and kernel but to be safe we also enforce the limit here.
+                            // This said writing more the Integer.MAX_VALUE is not a good idea anyway.
+                            //
+                            // See also:
+                            // - https://www.freebsd.org/cgi/man.cgi?query=write&sektion=2
+                            // - http://linux.die.net/man/2/writev
+                            break;
+                        }
+                        nioBufferSize += readableBytes;
+                        int count = entry.Count;
+                        if (count == -1)
+                        {
+                            //noinspection ConstantValueVariableUse
+                            entry.Count = count = buf.IoBufferCount;
+                        }
+                        if (count == 1)
+                        {
+                            ArraySegment<byte> nioBuf = entry.Buffer;
+                            if (nioBuf.Array == null)
+                            {
+                                // cache ByteBuffer as it may need to create a new ByteBuffer instance if its a
+                                // derived buffer
+                                entry.Buffer = nioBuf = buf.GetIoBuffer(readerIndex, readableBytes);
+                            }
+                            nioBuffers.Add(nioBuf);
+                        }
+                        else
+                        {
+                            ArraySegment<byte>[] nioBufs = entry.Buffers;
+                            if (nioBufs == null)
+                            {
+                                // cached ByteBuffers as they may be expensive to create in terms
+                                // of Object allocation
+                                entry.Buffers = nioBufs = buf.GetIoBuffers();
+                            }
+                            foreach (ArraySegment<byte> b in nioBufs)
+                            {
+                                nioBuffers.Add(b);
+                            }
+                        }
+                    }
+                }
+                entry = entry.Next;
+            }
+            this.NioBufferSize = nioBufferSize;
+
+            return nioBuffers;
+        }
+
+        /**
+         * Returns the number of bytes that can be written out of the {@link ByteBuffer} array that was
+         * obtained via {@link #nioBuffers()}. This method <strong>MUST</strong> be called after {@link #nioBuffers()}
+         * was called.
+         */
+        public long NioBufferSize { get; private set; }
+
+        /// <summary>
+        ///     Call {@link IMessageProcessor#processMessage(Object)} for each flushed message
+        ///     in this {@link ChannelOutboundBuffer} until {@link IMessageProcessor#processMessage(Object)}
+        ///     returns {@code false} or there are no more flushed messages to process.
+        /// </summary>
+        private bool IsFlushedEntry(Entry e) => e != null && e != this._unflushedEntry;
+
+        /// <summary>
         ///     Represents an entry inside the <see cref="ChannelOutboundBuffer" />
         /// </summary>
         private sealed class Entry
@@ -382,22 +522,22 @@ namespace Helios.Channels
 
             public bool Cancelled;
             public object Message;
+            public ArraySegment<byte>[] Buffers;
+            public ArraySegment<byte> Buffer;
             public Entry Next; //linked list
             public int PendingSize;
+            public int Count = -1;
             public TaskCompletionSource Promise;
-
-            public long Total;
 
             private Entry()
             {
             }
 
-            public static Entry NewInstance(object message, int size, long total, TaskCompletionSource promise)
+            public static Entry NewInstance(object message, int size, TaskCompletionSource promise)
             {
                 var entry = Pool.Value.Take();
                 entry.Message = message;
                 entry.PendingSize = size;
-                entry.Total = total;
                 entry.Promise = promise;
                 return entry;
             }
@@ -413,7 +553,8 @@ namespace Helios.Channels
                     ReferenceCountUtil.SafeRelease(Message);
                     Message = Unpooled.Empty;
                     PendingSize = 0;
-                    Total = 0;
+                    Buffers = null;
+                    Buffer = new ArraySegment<byte>();
                     return pSize;
                 }
                 return 0;
@@ -421,11 +562,13 @@ namespace Helios.Channels
 
             public void Recycle()
             {
-                Total = 0;
+                Buffers = null;
+                Buffer = new ArraySegment<byte>();
                 PendingSize = 0;
                 Message = null;
                 Next = null;
                 Promise = null;
+                Count = -1;
                 Cancelled = false;
                 Pool.Value.Free(this);
             }
@@ -435,6 +578,14 @@ namespace Helios.Channels
                 var next = Next;
                 Recycle();
                 return next;
+            }
+        }
+
+        private sealed class ThreadLocalByteBufferList : FastThreadLocal<List<ArraySegment<byte>>>
+        {
+            protected override List<ArraySegment<byte>> GetInitialValue()
+            {
+                return new List<ArraySegment<byte>>();
             }
         }
     }

--- a/src/Helios/Channels/ChannelOutboundBuffer.cs
+++ b/src/Helios/Channels/ChannelOutboundBuffer.cs
@@ -518,7 +518,7 @@ namespace Helios.Channels
         private sealed class Entry
         {
             private static readonly ThreadLocal<ObjectPool<Entry>> Pool =
-                new ThreadLocal<ObjectPool<Entry>>(() => new ObjectPool<Entry>(() => new Entry()));
+                new ThreadLocal<ObjectPool<Entry>>(() => new ObjectPool<Entry>(handle => new Entry(handle)));
 
             public bool Cancelled;
             public object Message;
@@ -528,9 +528,11 @@ namespace Helios.Channels
             public int PendingSize;
             public int Count = -1;
             public TaskCompletionSource Promise;
+            private readonly PoolHandle<Entry> handle;
 
-            private Entry()
+            private Entry(PoolHandle<Entry> handle)
             {
+                this.handle = handle;
             }
 
             public static Entry NewInstance(object message, int size, TaskCompletionSource promise)
@@ -570,7 +572,7 @@ namespace Helios.Channels
                 Promise = null;
                 Count = -1;
                 Cancelled = false;
-                Pool.Value.Free(this);
+               handle.Free(this);
             }
 
             public Entry RecycleAndGetNext()

--- a/src/Helios/Helios.csproj
+++ b/src/Helios/Helios.csproj
@@ -175,8 +175,11 @@
     <Compile Include="Logging\NoOpLogger.cs" />
     <Compile Include="Logging\NoOpLoggerFactory.cs" />
     <Compile Include="Logging\StandardOutLoggerFactory.cs" />
+    <Compile Include="Util\BitOps.cs" />
     <Compile Include="Util\Collections\PriorityQueue.cs" />
     <Compile Include="Util\Concurrency\TaskEx.cs" />
+    <Compile Include="Util\FastThreadLocal.cs" />
+    <Compile Include="Util\InternalThreadLocalMap.cs" />
     <Compile Include="Util\MonotonicClock.cs" />
     <Compile Include="Util\ObjectPool.cs" />
     <Compile Include="Util\RecyclableArrayList.cs" />

--- a/src/Helios/Net/Connections/TcpConnection.cs
+++ b/src/Helios/Net/Connections/TcpConnection.cs
@@ -349,7 +349,7 @@ namespace Helios.Net.Connections
 
         private void InitClient()
         {
-            _client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp)
+            _client = new Socket(Binding.Host.AddressFamily, SocketType.Stream, ProtocolType.Tcp)
             {
                 ReceiveTimeout = Timeout.Seconds,
                 SendTimeout = Timeout.Seconds,

--- a/src/Helios/Net/Connections/UdpConnection.cs
+++ b/src/Helios/Net/Connections/UdpConnection.cs
@@ -272,7 +272,7 @@ namespace Helios.Net.Connections
 
         protected void InitClient()
         {
-            Client = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)
+            Client = new Socket(Binding.Host.AddressFamily, SocketType.Dgram, ProtocolType.Udp)
             {
                 MulticastLoopback = false
             };

--- a/src/Helios/Reactor/ReactorBase.cs
+++ b/src/Helios/Reactor/ReactorBase.cs
@@ -30,7 +30,7 @@ namespace Helios.Reactor
             Encoder = encoder;
             Allocator = allocator;
             LocalEndpoint = new IPEndPoint(localAddress, localPort);
-            Listener = new Socket(AddressFamily.InterNetwork, socketType, protocol);
+            Listener = new Socket(LocalEndpoint.AddressFamily, socketType, protocol);
             if (protocol == ProtocolType.Tcp)
             {
                 Transport = TransportType.Tcp;

--- a/src/Helios/Reactor/Tcp/TcpProxyReactor.cs
+++ b/src/Helios/Reactor/Tcp/TcpProxyReactor.cs
@@ -33,7 +33,7 @@ namespace Helios.Reactor.Tcp
                 bufferSize)
         {
             LocalEndpoint = new IPEndPoint(localAddress, localPort);
-            Listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            Listener = new Socket(LocalEndpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
         }
 
         public override bool IsActive { get; protected set; }

--- a/src/Helios/Topology/NodeBuilder.cs
+++ b/src/Helios/Topology/NodeBuilder.cs
@@ -48,8 +48,11 @@ namespace Helios.Topology
             if (!IPAddress.TryParse(host, out parseIp))
             {
                 var hostentry = Dns.GetHostEntry(host);
-                parseIp = hostentry.AddressList.First(x => x.AddressFamily == AddressFamily.InterNetwork);
-                    //first IPv4 address
+                parseIp = hostentry.AddressList.FirstOrDefault(x => x.AddressFamily == AddressFamily.InterNetwork); // first IPv4 address
+                if (parseIp == null)
+                {
+                    parseIp = hostentry.AddressList.First(x => x.AddressFamily == AddressFamily.InterNetworkV6); // first IPv6 address
+                }
             }
 
             return Host(n, parseIp);

--- a/src/Helios/Topology/NodeUri.cs
+++ b/src/Helios/Topology/NodeUri.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Net;
+using System.Net.Sockets;
 using System.Runtime.Serialization;
 using Helios.Util;
 
@@ -33,7 +34,7 @@ namespace Helios.Topology
         public static string GetUriStringForNode(INode node)
         {
             if (node.IsEmpty()) return string.Empty;
-            return string.Format("{0}://{1}:{2}", GetProtocolStringForTransportType(node.TransportType), node.Host,
+            return string.Format("{0}://{1}:{2}", GetProtocolStringForTransportType(node.TransportType), GetHostStringForAddress(node.Host),
                 node.Port);
         }
 
@@ -48,6 +49,16 @@ namespace Helios.Topology
                 default:
                     return "socket";
             }
+        }
+
+        public static string GetHostStringForAddress(IPAddress address)
+        {
+            var host = address.ToString();
+            if (address.AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                host = string.Format("[{0}]", host);
+            }
+            return host;
         }
 
 #if !NET35 && !NET40

--- a/src/Helios/Util/BitOps.cs
+++ b/src/Helios/Util/BitOps.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Helios.Util
+{
+    public static class BitOps
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int RightUShift(this int value, int bits) => unchecked((int)((uint)value >> bits));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long RightUShift(this long value, int bits) => unchecked((long)((ulong)value >> bits));
+    }
+}

--- a/src/Helios/Util/ByteArrayExtensions.cs
+++ b/src/Helios/Util/ByteArrayExtensions.cs
@@ -3,6 +3,7 @@
 // See ThirdPartyNotices.txt for references to third party code used inside Helios.
 
 using System;
+using System.Diagnostics.Contracts;
 
 namespace Helios.Util
 {
@@ -54,6 +55,24 @@ namespace Helios.Util
                         srcIndex, srcLength, src.Length));
 
             Array.Copy(src, srcIndex, array, index, srcLength);
+        }
+
+        public static void Fill<T>(this T[] array, T value)
+        {
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = value;
+            }
+        }
+
+        public static void Fill<T>(this T[] array, int offset, int count, T value)
+        {
+            Contract.Requires(count + offset <= array.Length);
+
+            for (int i = offset; i < count + offset; i++)
+            {
+                array[i] = value;
+            }
         }
     }
 }

--- a/src/Helios/Util/FastThreadLocal.cs
+++ b/src/Helios/Util/FastThreadLocal.cs
@@ -1,0 +1,196 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Helios.Util
+{
+    public abstract class FastThreadLocal
+    {
+        static readonly int VariablesToRemoveIndex = InternalThreadLocalMap.NextVariableIndex();
+
+        /// <summary>
+        ///     Removes all {@link FastThreadLocal} variables bound to the current thread.  This operation is useful when you
+        ///     are in a container environment, and you don't want to leave the thread local variables in the threads you do not
+        ///     manage.
+        /// </summary>
+        public static void RemoveAll()
+        {
+            InternalThreadLocalMap threadLocalMap = InternalThreadLocalMap.GetIfSet();
+            if (threadLocalMap == null)
+            {
+                return;
+            }
+
+            try
+            {
+                object v = threadLocalMap.GetIndexedVariable(VariablesToRemoveIndex);
+                if (v != null && v != InternalThreadLocalMap.Unset)
+                {
+                    var variablesToRemove = (HashSet<FastThreadLocal>)v;
+                    foreach (FastThreadLocal tlv in variablesToRemove) // todo: do we need to make a snapshot?
+                    {
+                        tlv.Remove(threadLocalMap);
+                    }
+                }
+            }
+            finally
+            {
+                InternalThreadLocalMap.Remove();
+            }
+        }
+
+        /// Destroys the data structure that keeps all {@link FastThreadLocal} variables accessed from
+        /// non-{@link FastThreadLocalThread}s.  This operation is useful when you are in a container environment, and you
+        /// do not want to leave the thread local variables in the threads you do not manage.  Call this method when your
+        /// application is being unloaded from the container.
+        public static void Destroy() => InternalThreadLocalMap.Destroy();
+
+        protected static void AddToVariablesToRemove(InternalThreadLocalMap threadLocalMap, FastThreadLocal variable)
+        {
+            object v = threadLocalMap.GetIndexedVariable(VariablesToRemoveIndex);
+            HashSet<FastThreadLocal> variablesToRemove;
+            if (v == InternalThreadLocalMap.Unset || v == null)
+            {
+                variablesToRemove = new HashSet<FastThreadLocal>(); // Collections.newSetFromMap(new IdentityHashMap<FastThreadLocal<?>, Boolean>());
+                threadLocalMap.SetIndexedVariable(VariablesToRemoveIndex, variablesToRemove);
+            }
+            else
+            {
+                variablesToRemove = (HashSet<FastThreadLocal>)v;
+            }
+
+            variablesToRemove.Add(variable);
+        }
+
+        protected static void RemoveFromVariablesToRemove(InternalThreadLocalMap threadLocalMap, FastThreadLocal variable)
+        {
+            object v = threadLocalMap.GetIndexedVariable(VariablesToRemoveIndex);
+
+            if (v == InternalThreadLocalMap.Unset || v == null)
+            {
+                return;
+            }
+
+            var variablesToRemove = (HashSet<FastThreadLocal>)v;
+            variablesToRemove.Remove(variable);
+        }
+
+        /// <summary>
+        ///     Sets the value to uninitialized; a proceeding call to get() will trigger a call to GetInitialValue().
+        /// </summary>
+        /// <param name="threadLocalMap"></param>
+        public abstract void Remove(InternalThreadLocalMap threadLocalMap);
+    }
+
+    public class FastThreadLocal<T> : FastThreadLocal
+        where T : class
+    {
+        readonly int index;
+
+        /// <summary>
+        ///     Returns the number of thread local variables bound to the current thread.
+        /// </summary>
+        public static int Count => InternalThreadLocalMap.GetIfSet()?.Count ?? 0;
+
+        public FastThreadLocal()
+        {
+            this.index = InternalThreadLocalMap.NextVariableIndex();
+        }
+
+        /// <summary>
+        ///     Gets or sets current value for the current thread.
+        /// </summary>
+        public T Value
+        {
+            get { return this.Get(InternalThreadLocalMap.Get()); }
+            set { this.Set(InternalThreadLocalMap.Get(), value); }
+        }
+
+        /// <summary>
+        ///     Returns the current value for the specified thread local map.
+        ///     The specified thread local map must be for the current thread.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public T Get(InternalThreadLocalMap threadLocalMap)
+        {
+            object v = threadLocalMap.GetIndexedVariable(this.index);
+            if (v != InternalThreadLocalMap.Unset)
+            {
+                return (T)v;
+            }
+
+            return this.Initialize(threadLocalMap);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        T Initialize(InternalThreadLocalMap threadLocalMap)
+        {
+            T v = this.GetInitialValue();
+
+            threadLocalMap.SetIndexedVariable(this.index, v);
+            AddToVariablesToRemove(threadLocalMap, this);
+            return v;
+        }
+
+        /// <summary>
+        ///     Set the value for the specified thread local map. The specified thread local map must be for the current thread.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Set(InternalThreadLocalMap threadLocalMap, T value)
+        {
+            if (threadLocalMap.SetIndexedVariable(this.index, value))
+            {
+                AddToVariablesToRemove(threadLocalMap, this);
+            }
+        }
+
+        /// <summary>
+        ///     Returns {@code true} if and only if this thread-local variable is set.
+        /// </summary>
+        public bool IsSet() => this.IsSet(InternalThreadLocalMap.GetIfSet());
+
+        /// <summary>
+        ///     Returns {@code true} if and only if this thread-local variable is set.
+        ///     The specified thread local map must be for the current thread.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsSet(InternalThreadLocalMap threadLocalMap) => threadLocalMap != null && threadLocalMap.IsIndexedVariableSet(this.index);
+
+        /// <summary>
+        ///     Returns the initial value for this thread-local variable.
+        /// </summary>
+        protected virtual T GetInitialValue() => null;
+
+        public void Remove() => this.Remove(InternalThreadLocalMap.GetIfSet());
+
+        /// Sets the value to uninitialized for the specified thread local map;
+        /// a proceeding call to get() will trigger a call to GetInitialValue().
+        /// The specified thread local map must be for the current thread.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public sealed override void Remove(InternalThreadLocalMap threadLocalMap)
+        {
+            if (threadLocalMap == null)
+            {
+                return;
+            }
+
+            object v = threadLocalMap.RemoveIndexedVariable(this.index);
+            RemoveFromVariablesToRemove(threadLocalMap, this);
+
+            if (v != InternalThreadLocalMap.Unset)
+            {
+                this.OnRemoval((T)v);
+            }
+        }
+
+        /// <summary>
+        ///     Invoked when this thread local variable is removed by {@link #remove()}.
+        /// </summary>
+        protected virtual void OnRemoval(T value)
+        {
+        }
+    }
+}

--- a/src/Helios/Util/InternalThreadLocalMap.cs
+++ b/src/Helios/Util/InternalThreadLocalMap.cs
@@ -1,0 +1,210 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Helios.Util
+{
+    /// <summary>
+    ///     The internal data structure that stores the thread-local variables for Netty and all {@link FastThreadLocal}s.
+    ///     Note that this class is for internal use only and is subject to change at any time.  Use {@link FastThreadLocal}
+    ///     unless you know what you are doing.
+    /// </summary>
+    public sealed class InternalThreadLocalMap
+    {
+        public static readonly object Unset = new object();
+
+        [ThreadStatic]
+        static InternalThreadLocalMap slowThreadLocalMap;
+
+        static int nextIndex;
+
+        /// Used by {@link FastThreadLocal}
+        object[] indexedVariables;
+
+        // Core thread-locals
+        int futureListenerStackDepth;
+        int localChannelReaderStackDepth;
+
+        // String-related thread-locals
+        StringBuilder stringBuilder;
+
+        internal static int NextVariableIndex()
+        {
+            int index = Interlocked.Increment(ref nextIndex);
+            if (index < 0)
+            {
+                Interlocked.Decrement(ref nextIndex);
+                throw new InvalidOperationException("too many thread-local indexed variables");
+            }
+            return index;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static InternalThreadLocalMap GetIfSet() => slowThreadLocalMap;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static InternalThreadLocalMap Get()
+        {
+            InternalThreadLocalMap ret = slowThreadLocalMap;
+            if (ret == null)
+            {
+                ret = new InternalThreadLocalMap();
+                slowThreadLocalMap = ret;
+            }
+            return ret;
+        }
+
+        public static void Remove() => slowThreadLocalMap = null;
+
+        public static void Destroy() => slowThreadLocalMap = null;
+
+        // Cache line padding (must be public)
+        // With CompressedOops enabled, an instance of this class should occupy at least 128 bytes.
+        public long rp1, rp2, rp3, rp4, rp5, rp6, rp7, rp8, rp9;
+
+        InternalThreadLocalMap()
+        {
+            this.indexedVariables = CreateIndexedVariableTable();
+        }
+
+        static object[] CreateIndexedVariableTable()
+        {
+            var array = new object[32];
+
+            array.Fill(Unset);
+            return array;
+        }
+
+        public int Count
+        {
+            get
+            {
+                int count = 0;
+
+                if (this.futureListenerStackDepth != 0)
+                {
+                    count++;
+                }
+                if (this.localChannelReaderStackDepth != 0)
+                {
+                    count++;
+                }
+                if (this.stringBuilder != null)
+                {
+                    count++;
+                }
+                foreach (object o in this.indexedVariables)
+                {
+                    if (o != Unset)
+                    {
+                        count++;
+                    }
+                }
+
+                // We should subtract 1 from the count because the first element in 'indexedVariables' is reserved
+                // by 'FastThreadLocal' to keep the list of 'FastThreadLocal's to remove on 'FastThreadLocal.RemoveAll()'.
+                return count - 1;
+            }
+        }
+
+        public StringBuilder StringBuilder
+        {
+            get
+            {
+                StringBuilder builder = this.stringBuilder;
+                if (builder == null)
+                {
+                    this.stringBuilder = builder = new StringBuilder(512);
+                }
+                else
+                {
+                    builder.Length = 0;
+                }
+                return builder;
+            }
+        }
+
+        public int FutureListenerStackDepth
+        {
+            get { return this.futureListenerStackDepth; }
+            set { this.futureListenerStackDepth = value; }
+        }
+
+        public int LocalChannelReaderStackDepth
+        {
+            get { return this.localChannelReaderStackDepth; }
+            set { this.localChannelReaderStackDepth = value; }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public object GetIndexedVariable(int index)
+        {
+            object[] lookup = this.indexedVariables;
+            return index < lookup.Length ? lookup[index] : Unset;
+        }
+
+        /**
+     * @return {@code true} if and only if a new thread-local variable has been created
+     */
+
+        public bool SetIndexedVariable(int index, object value)
+        {
+            object[] lookup = this.indexedVariables;
+            if (index < lookup.Length)
+            {
+                object oldValue = lookup[index];
+                lookup[index] = value;
+                return oldValue == Unset;
+            }
+            else
+            {
+                this.ExpandIndexedVariableTableAndSet(index, value);
+                return true;
+            }
+        }
+
+        void ExpandIndexedVariableTableAndSet(int index, object value)
+        {
+            object[] oldArray = this.indexedVariables;
+            int oldCapacity = oldArray.Length;
+            int newCapacity = index;
+            newCapacity |= newCapacity.RightUShift(1);
+            newCapacity |= newCapacity.RightUShift(2);
+            newCapacity |= newCapacity.RightUShift(4);
+            newCapacity |= newCapacity.RightUShift(8);
+            newCapacity |= newCapacity.RightUShift(16);
+            newCapacity++;
+
+            var newArray = new object[newCapacity];
+            oldArray.CopyTo(newArray, 0);
+            newArray.Fill(oldCapacity, newArray.Length - oldCapacity, Unset);
+            newArray[index] = value;
+            this.indexedVariables = newArray;
+        }
+
+        public object RemoveIndexedVariable(int index)
+        {
+            object[] lookup = this.indexedVariables;
+            if (index < lookup.Length)
+            {
+                object v = lookup[index];
+                lookup[index] = Unset;
+                return v;
+            }
+            else
+            {
+                return Unset;
+            }
+        }
+
+        public bool IsIndexedVariableSet(int index)
+        {
+            object[] lookup = this.indexedVariables;
+            return index < lookup.Length && lookup[index] != Unset;
+        }
+    }
+}

--- a/src/Helios/Util/RecyclableArrayList.cs
+++ b/src/Helios/Util/RecyclableArrayList.cs
@@ -11,7 +11,14 @@ namespace Helios.Util
     {
         private static readonly ThreadLocal<ObjectPool<RecyclableArrayList>> _pool =
             new ThreadLocal<ObjectPool<RecyclableArrayList>>(
-                () => new ObjectPool<RecyclableArrayList>(() => new RecyclableArrayList()));
+                () => new ObjectPool<RecyclableArrayList>(handle => new RecyclableArrayList(handle)));
+
+        private readonly PoolHandle<RecyclableArrayList> _handle;
+
+        public RecyclableArrayList(PoolHandle<RecyclableArrayList> handle)
+        {
+            _handle = handle;
+        }
 
         public static RecyclableArrayList Take()
         {
@@ -21,7 +28,7 @@ namespace Helios.Util
         public void Return()
         {
             Clear();
-            _pool.Value.Free(this); // return to the pool
+            _handle.Free(this); // return to the pool
         }
     }
 }

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -3,5 +3,5 @@ using System.Reflection;
 
 [assembly: AssemblyCompanyAttribute("Helios Framework")]
 [assembly: AssemblyCopyrightAttribute("Copyright © Aaron Stannard 2013-2015")]
-[assembly: AssemblyVersionAttribute("2.0.2")]
-[assembly: AssemblyFileVersionAttribute("2.0.2")]
+[assembly: AssemblyVersionAttribute("2.1.0")]
+[assembly: AssemblyFileVersionAttribute("2.1.0")]

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -3,5 +3,5 @@ using System.Reflection;
 
 [assembly: AssemblyCompanyAttribute("Helios Framework")]
 [assembly: AssemblyCopyrightAttribute("Copyright © Aaron Stannard 2013-2015")]
-[assembly: AssemblyVersionAttribute("2.0")]
-[assembly: AssemblyFileVersionAttribute("2.0")]
+[assembly: AssemblyVersionAttribute("2.0.2")]
+[assembly: AssemblyFileVersionAttribute("2.0.2")]

--- a/tests/Helios.FsCheck.Tests/Concurrency/ObjectPoolSpec.cs
+++ b/tests/Helios.FsCheck.Tests/Concurrency/ObjectPoolSpec.cs
@@ -21,7 +21,7 @@ namespace Helios.FsCheck.Tests.Concurrency
         public static readonly int ObjectCount = Environment.ProcessorCount*2;
         private readonly ObjectPool<MyPooledObject> _pool;
 
-        private readonly Func<MyPooledObject> _producer = () => new MyPooledObject();
+        private readonly Func<PoolHandle<MyPooledObject>, MyPooledObject> _producer = handle => new MyPooledObject(handle);
 
         public ObjectPoolSpec()
         {
@@ -52,7 +52,7 @@ namespace Helios.FsCheck.Tests.Concurrency
             {
                 var propsEqual = o.Num == tuple.Item1 && o.Num2 == tuple.Item2;
                 pooledObjects.Add(o); //add a reference to O
-                _pool.Free(o);
+                o.Recycle();
                 return propsEqual;
             };
 
@@ -78,6 +78,13 @@ namespace Helios.FsCheck.Tests.Concurrency
 
         private class MyPooledObject
         {
+            private PoolHandle<MyPooledObject> _handle;
+
+            public MyPooledObject(PoolHandle<MyPooledObject> handle)
+            {
+                _handle = handle;
+            }
+
             public int Num { get; set; }
             public int Num2 { get; set; }
 
@@ -85,6 +92,7 @@ namespace Helios.FsCheck.Tests.Concurrency
             {
                 Num = 0;
                 Num2 = 0;
+                _handle.Free(this);
             }
         }
     }

--- a/tests/Helios.Tests/Buffer/ByteBufferTests.cs
+++ b/tests/Helios.Tests/Buffer/ByteBufferTests.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 // See ThirdPartyNotices.txt for references to third party code used inside Helios.
 
+using System;
 using System.Linq;
 using System.Text;
 using Helios.Buffers;
+using Helios.Util;
 using Xunit;
 
 namespace Helios.Tests.Buffer
@@ -183,6 +185,26 @@ namespace Helios.Tests.Buffer
             Assert.Equal(110, originalByteBuffer.ReadInt());
             var byteArray = originalByteBuffer.ToArray();
             Assert.Equal(expectedString, Encoding.Unicode.GetString(byteArray));
+        }
+
+        #endregion
+
+        #region Array operations
+
+        [Fact]
+        public void Should_get_correct_ArrayOffset_and_copy_ByteBuffer_contents_to_array()
+        {
+            var originalBuffer = GetBuffer(1024);
+            var bytes = Guid.NewGuid().ToByteArray();
+
+            // advance the read position beyond the original value
+            originalBuffer.WriteInt(4).WriteBytes(bytes);
+            var myInt = originalBuffer.ReadInt();
+            Assert.Equal(4, myInt);
+
+            var newBytes = new byte[originalBuffer.ReadableBytes];
+            Array.Copy(originalBuffer.Array, originalBuffer.ArrayOffset + originalBuffer.ReaderIndex, newBytes, 0, originalBuffer.ReadableBytes);
+            Assert.True(bytes.SequenceEqual(newBytes));
         }
 
         #endregion

--- a/tests/Helios.Tests/Buffer/ByteBufferTests.cs
+++ b/tests/Helios.Tests/Buffer/ByteBufferTests.cs
@@ -224,6 +224,55 @@ namespace Helios.Tests.Buffer
         }
 
         #endregion
+
+        #region IO Buffers
+
+        [Fact]
+        public void IoBuffer_contents_should_equal_write()
+        {
+            var buffer = GetBuffer(1024);
+            if (buffer.IoBufferCount != 1)
+            {
+                // skipping
+                return; 
+            }
+
+            var bytes = new byte[buffer.Capacity];
+            ThreadLocalRandom.Current.NextBytes(bytes);
+            buffer.WriteBytes(bytes);
+
+            AssertRemainingEquals(new ArraySegment<byte>(bytes), buffer.GetIoBuffer());
+        }
+
+        [Fact]
+        public void IoBuffer_contents_in_range_should_equal_write()
+        {
+            var buffer = GetBuffer(1024);
+            if (buffer.IoBufferCount != 1)
+            {
+                // skipping
+                return;
+            }
+
+            var bytes = new byte[buffer.Capacity];
+            buffer.WriteBytes(bytes);
+            var blockSize = buffer.Capacity/100;
+            for (var i = 0; i < buffer.Capacity - blockSize + 1; i += blockSize)
+            {
+                AssertRemainingEquals(new ArraySegment<byte>(bytes, i, blockSize), buffer.GetIoBuffer(i, blockSize));
+            }
+        }
+
+        static void AssertRemainingEquals(ArraySegment<byte> expected, ArraySegment<byte> actual)
+        {
+            int remaining = expected.Count;
+            int remaining2 = actual.Count;
+
+            Assert.Equal(remaining, remaining2);
+            Assert.Equal(expected, actual);
+        }
+
+        #endregion
     }
 }
 

--- a/tests/Helios.Tests/Buffer/ByteBufferTests.cs
+++ b/tests/Helios.Tests/Buffer/ByteBufferTests.cs
@@ -207,6 +207,22 @@ namespace Helios.Tests.Buffer
             Assert.True(bytes.SequenceEqual(newBytes));
         }
 
+        [Fact]
+        public void Should_get_correct_ArrayOffset_and_copy_SlicedByteBuffer_contents_to_array()
+        {
+            var originalBuffer = GetBuffer(1024);
+            var bytes = Guid.NewGuid().ToByteArray();
+
+            // advance the read position beyond the original value
+            originalBuffer.WriteInt(4).WriteBytes(bytes);
+
+            var sliced = originalBuffer.Slice(4, originalBuffer.ReadableBytes - 4);
+
+            var newBytes = new byte[sliced.ReadableBytes];
+            Array.Copy(sliced.Array, sliced.ArrayOffset + sliced.ReaderIndex, newBytes, 0, sliced.ReadableBytes);
+            Assert.True(bytes.SequenceEqual(newBytes));
+        }
+
         #endregion
     }
 }

--- a/tests/Helios.Tests/Channels/Bootstrap/TcpBootstrapSpec.cs
+++ b/tests/Helios.Tests/Channels/Bootstrap/TcpBootstrapSpec.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Helios.Channels;
+using Helios.Channels.Bootstrap;
+using Helios.Channels.Sockets;
+using Xunit;
+
+namespace Helios.Tests.Channels.Bootstrap
+{
+    public class TcpBootstrapSpec : IDisposable
+    {
+        private MultithreadEventLoopGroup _serverGroup = new MultithreadEventLoopGroup(1);
+
+        [Fact]
+        public void ServerBootrap_must_support_BindAsync_on_DnsEndpoints_for_SocketChannels()
+        {
+
+            var sb = new ServerBootstrap()
+                .Channel<TcpServerSocketChannel>()
+                .ChildHandler(new ActionChannelInitializer<TcpSocketChannel>(channel => { }))
+                .Group(_serverGroup);
+
+            var c = sb.BindAsync(new DnsEndPoint("localhost", 0)).Result;
+        }
+
+        public void Dispose()
+        {
+            _serverGroup.ShutdownGracefullyAsync();
+        }
+    }
+}

--- a/tests/Helios.Tests/Helios.Tests.csproj
+++ b/tests/Helios.Tests/Helios.Tests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Buffer\UnpooledDirectByteBufferTests.cs" />
     <Compile Include="Channels\AbstractChannelHandlerContextSpecs.cs" />
     <Compile Include="Channels\Bootstrap\BootstrapSpecs.cs" />
+    <Compile Include="Channels\Bootstrap\TcpBootstrapSpec.cs" />
     <Compile Include="Channels\Embedded\EmbeddedChannelTest.cs" />
     <Compile Include="Channels\IntCodec.cs" />
     <Compile Include="Channels\Local\LocalChannelTest.cs" />

--- a/tests/Helios.Tests/Net/TcpConnectionTests.cs
+++ b/tests/Helios.Tests/Net/TcpConnectionTests.cs
@@ -37,6 +37,28 @@ namespace Helios.Tests.Net
             Assert.True(boolDisconnected);
         }
 
+        [Fact]
+        public void Should_not_throw_exception_when_connecting_via_ipv6()
+        {
+            // arrange
+            var node = NodeBuilder.BuildNode().Host(IPAddress.IPv6Loopback).WithPort(11111);
+            var connection = node.GetConnection();
+            var boolDisconnected = false;
+            var resetEvent = new AutoResetEvent(false);
+            connection.OnDisconnection += delegate
+            {
+                boolDisconnected = true;
+                resetEvent.Set();
+            };
+
+            // act
+            connection.Open();
+            resetEvent.WaitOne();
+
+            // assert
+            Assert.True(boolDisconnected);
+        }
+
         #endregion
 
         #region Setup / Teardown

--- a/tests/Helios.Tests/Topology/NodeUriTests.cs
+++ b/tests/Helios.Tests/Topology/NodeUriTests.cs
@@ -35,6 +35,23 @@ namespace Helios.Tests.Topology
         }
 
         [Fact]
+        public void Should_convert_valid_ipv6_tcp_INode_to_NodeUri()
+        {
+            //arrange
+            var testNode =
+                NodeBuilder.BuildNode().Host(IPAddress.IPv6Loopback).WithPort(1337).WithTransportType(TransportType.Tcp);
+
+            //act
+            var nodeUri = new NodeUri(testNode);
+
+            //assert
+            Assert.Equal(testNode.Port, nodeUri.Port);
+            Assert.Equal(string.Format("[{0}]", testNode.Host), nodeUri.Host);
+            Assert.Equal("tcp", nodeUri.Scheme);
+            Assert.True(nodeUri.IsLoopback);
+        }
+
+        [Fact]
         public void Should_convert_valid_tcp_NodeUri_to_INode()
         {
             //arrange


### PR DESCRIPTION
#### 2.1.0 May 16 2016
* Added support for batch writes
* Made write objects reusable
* IPv6 support for legacy API

Net performance impact of above changes as reported by build server:

**Before**

          Metric |           Units |             Max |         Average |             Min |          StdDev |
---------------- |---------------- |---------------- |---------------- |---------------- |---------------- |
TotalCollections [Gen0] |     collections / s |           40.14 |           40.14 |           40.14 |            0.00 |
TotalCollections [Gen1] |     collections / s |            2.86 |            2.86 |            2.86 |            0.00 |
TotalCollections [Gen2] |     collections / s |            0.53 |            0.53 |            0.53 |            0.00 |
TotalBytesAllocated |           bytes / s |      293,950.63 |      293,950.63 |      293,950.63 |            0.00 |
[Counter] inbound ops |      operations / s |       55,782.90 |       55,782.90 |       55,782.90 |            0.00 |
[Counter] outbound ops |      operations / |       55,783.07 |       55,783.07 |       55,783.07 |            0.00 |
Max concurrent connections |      operations |          440.00 |          440.00 |          440.00 |            0.00 |

**After**

          Metric |           Units |             Max |         Average |             Min |          StdDev |
---------------- |---------------- |---------------- |---------------- |---------------- |---------------- |
TotalCollections [Gen0] |     collections |           26.41 |           26.41 |           26.41 |            0.00 |
TotalCollections [Gen1] |     collections |            8.33 |            8.33 |            8.33 |            0.00 |
TotalCollections [Gen2] |     collections |            0.08 |            0.08 |            0.08 |            0.00 |
TotalBytesAllocated |           bytes |       38,170.63 |       38,170.63 |       38,170.63 |            0.00 |
[Counter] inbound ops |      operations |       99,728.63 |       99,728.63 |       99,728.63 |            0.00 |
[Counter] outbound ops |      operations |       99,728.67 |       99,728.67 |       99,728.67 |            0.00 |
Max concurrent connections |      operations |          945.00 |          945.00 |          945.00 |            0.00 | 