### PR TITLE
changed all bitshift operations to be in little endian

### DIFF
--- a/src/Helios/Buffers/AbstractDerivedByteBuffer.cs
+++ b/src/Helios/Buffers/AbstractDerivedByteBuffer.cs
@@ -20,22 +20,26 @@ namespace Helios.Buffers
 
         public override IReferenceCounted Retain()
         {
-            return Unwrap().Retain();
+            Unwrap().Retain();
+            return this;
         }
 
         public override IReferenceCounted Retain(int increment)
         {
-            return Unwrap().Retain(increment);
+            Unwrap().Retain(increment);
+            return this;
         }
 
         public override IReferenceCounted Touch()
         {
-            return Unwrap().Touch();
+            Unwrap().Touch();
+            return this;
         }
 
         public override IReferenceCounted Touch(object hint)
         {
-            return Unwrap().Touch(hint);
+            Unwrap().Touch(hint);
+            return this;
         }
 
         public override bool Release()

--- a/src/Helios/Buffers/UnpooledDirectByteBuf.cs
+++ b/src/Helios/Buffers/UnpooledDirectByteBuf.cs
@@ -107,30 +107,30 @@ namespace Helios.Buffers
 
         protected override short _GetShort(int index)
         {
-            return unchecked((short) (_buffer[index] << 8 | _buffer[index + 1]));
+            return unchecked((short) (_buffer[index] | _buffer[index + 1] << 8));
         }
 
         protected override int _GetInt(int index)
         {
-            return unchecked(_buffer[index] << 24 |
-                             _buffer[index + 1] << 16 |
-                             _buffer[index + 2] << 8 |
-                             _buffer[index + 3]);
+            return unchecked(_buffer[index] |
+                             _buffer[index + 1] << 8 |
+                             _buffer[index + 2] << 16 |
+                             _buffer[index + 3] << 24);
         }
 
         protected override long _GetLong(int index)
         {
             unchecked
             {
-                var i1 = _buffer[index] << 24 |
-                         _buffer[index + 1] << 16 |
-                         _buffer[index + 2] << 8 |
-                         _buffer[index + 3];
-                var i2 = _buffer[index + 4] << 24 |
-                         _buffer[index + 5] << 16 |
-                         _buffer[index + 6] << 8 |
-                         _buffer[index + 7];
-                return (uint) i2 | ((long) i1 << 32);
+                var i1 = _buffer[index]  |
+                         _buffer[index + 1] << 8 |
+                         _buffer[index + 2] << 16 |
+                         _buffer[index + 3] << 24;
+                var i2 = _buffer[index + 4]  |
+                         _buffer[index + 5] << 8 |
+                         _buffer[index + 6] << 16 |
+                         _buffer[index + 7] << 24;
+                return (uint) i1 | ((long) i2 << 32);
             }
         }
 
@@ -165,8 +165,8 @@ namespace Helios.Buffers
         {
             unchecked
             {
-                _buffer[index] = (byte) ((ushort) value >> 8);
-                _buffer[index + 1] = (byte) value;
+                _buffer[index] = (byte) ((ushort) value);
+                _buffer[index + 1] = (byte) ((ushort)value >> 8);
             }
             return this;
         }
@@ -176,10 +176,10 @@ namespace Helios.Buffers
             unchecked
             {
                 var unsignedValue = (uint) value;
-                _buffer[index] = (byte) (unsignedValue >> 24);
-                _buffer[index + 1] = (byte) (unsignedValue >> 16);
-                _buffer[index + 2] = (byte) (unsignedValue >> 8);
-                _buffer[index + 3] = (byte) value;
+                _buffer[index] = (byte) (value);
+                _buffer[index + 1] = (byte) (unsignedValue >> 8);
+                _buffer[index + 2] = (byte) (unsignedValue >> 16);
+                _buffer[index + 3] = (byte) (unsignedValue >> 24);
             }
             return this;
         }
@@ -189,14 +189,14 @@ namespace Helios.Buffers
             unchecked
             {
                 var unsignedValue = (ulong) value;
-                _buffer[index] = (byte) (unsignedValue >> 56);
-                _buffer[index + 1] = (byte) (unsignedValue >> 48);
-                _buffer[index + 2] = (byte) (unsignedValue >> 40);
-                _buffer[index + 3] = (byte) (unsignedValue >> 32);
-                _buffer[index + 4] = (byte) (unsignedValue >> 24);
-                _buffer[index + 5] = (byte) (unsignedValue >> 16);
-                _buffer[index + 6] = (byte) (unsignedValue >> 8);
-                _buffer[index + 7] = (byte) value;
+                _buffer[index] = (byte) (value);
+                _buffer[index + 1] = (byte) (unsignedValue >> 8);
+                _buffer[index + 2] = (byte) (unsignedValue >> 16);
+                _buffer[index + 3] = (byte) (unsignedValue >> 24);
+                _buffer[index + 4] = (byte) (unsignedValue >> 32);
+                _buffer[index + 5] = (byte) (unsignedValue >> 40);
+                _buffer[index + 6] = (byte) (unsignedValue >> 48);
+                _buffer[index + 7] = (byte) (unsignedValue >> 56);
             }
             return this;
         }

--- a/src/Helios/Codecs/LengthFieldPrepender.cs
+++ b/src/Helios/Codecs/LengthFieldPrepender.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using Helios.Buffers;
 using Helios.Channels;
 
@@ -143,7 +145,6 @@ namespace Helios.Codecs
                 default:
                     throw new Exception("Unknown length field length");
             }
-
             output.Add(message.Retain());
         }
     }

--- a/tests/Helios.FsCheck.Tests/Buffers/BufferSpecs.cs
+++ b/tests/Helios.FsCheck.Tests/Buffers/BufferSpecs.cs
@@ -119,6 +119,57 @@ namespace Helios.FsCheck.Tests.Buffers
             swappedWritesCanBeSwappedBack.QuickCheckThrowOnFailure();
         }
 
+        [Theory]
+        [InlineData(typeof(UnpooledByteBufAllocator))]
+        public void Buffer_default_write_int_should_be_little_endian(Type allocatorType)
+        {
+            Assert.True(BitConverter.IsLittleEndian, "this spec is designed for little endian hardware");
+            var allocator = (IByteBufAllocator)Activator.CreateInstance(allocatorType);
+            var writesInLittleEndian = Prop.ForAll<int>(i =>
+            {
+                var littleEndianBytes = BitConverter.GetBytes(i);
+                var buf = allocator.Buffer(littleEndianBytes.Length).WriteInt(i);
+                return littleEndianBytes.SequenceEqual(buf.Array)
+                    .Label("Expected little endian byte array. Was not.")
+                    .And(() => i == buf.ReadInt());
+            });
+            writesInLittleEndian.QuickCheckThrowOnFailure();
+        }
+
+        [Theory]
+        [InlineData(typeof(UnpooledByteBufAllocator))]
+        public void Buffer_default_write_long_should_be_little_endian(Type allocatorType)
+        {
+            Assert.True(BitConverter.IsLittleEndian, "this spec is designed for little endian hardware");
+            var allocator = (IByteBufAllocator)Activator.CreateInstance(allocatorType);
+            var writesInLittleEndian = Prop.ForAll<long>(i =>
+            {
+                var littleEndianBytes = BitConverter.GetBytes(i);
+                var buf = allocator.Buffer(littleEndianBytes.Length).WriteLong(i);
+                return littleEndianBytes.SequenceEqual(buf.Array)
+                    .Label("Expected little endian byte array. Was not.")
+                    .And(() => i == buf.ReadLong());
+            });
+            writesInLittleEndian.QuickCheckThrowOnFailure();
+        }
+
+        [Theory]
+        [InlineData(typeof(UnpooledByteBufAllocator))]
+        public void UnpooledDirectByteBuffer_default_write_short_should_be_little_endian(Type allocatorType)
+        {
+            Assert.True(BitConverter.IsLittleEndian, "this spec is designed for little endian hardware");
+            var allocator = (IByteBufAllocator)Activator.CreateInstance(allocatorType);
+            var writesInLittleEndian = Prop.ForAll<short>(i =>
+            {
+                var littleEndianBytes = BitConverter.GetBytes(i);
+                var buf = allocator.Buffer(littleEndianBytes.Length).WriteShort(i);
+                return littleEndianBytes.SequenceEqual(buf.Array)
+                    .Label("Expected little endian byte array. Was not.")
+                    .And(() => i == buf.ReadShort());
+            });
+            writesInLittleEndian.QuickCheckThrowOnFailure();
+        }
+
         [Property]
         public Property Buffer_should_be_able_to_WriteZero_for_sizes_within_MaxCapacity(BufferSize initialSize,
             int length)

--- a/tests/Helios.Tests/Buffer/UnpooledDirectByteBufferTests.cs
+++ b/tests/Helios.Tests/Buffer/UnpooledDirectByteBufferTests.cs
@@ -2,7 +2,10 @@
 // Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
 // See ThirdPartyNotices.txt for references to third party code used inside Helios.
 
+using System;
+using System.Linq;
 using Helios.Buffers;
+using Xunit;
 
 namespace Helios.Tests.Buffer
 {
@@ -16,6 +19,36 @@ namespace Helios.Tests.Buffer
         protected override IByteBuf GetBuffer(int initialCapacity, int maxCapacity)
         {
             return UnpooledByteBufAllocator.Default.Buffer(initialCapacity, maxCapacity);
+        }
+
+        [Fact]
+        public void UnpooledDirectByteBuffer_write_int_little_endian()
+        {
+            Assert.True(BitConverter.IsLittleEndian, "this spec is designed for little endian hardware");
+            var testInt = 1;
+            var littleEndianBytes = BitConverter.GetBytes(testInt);
+            var buf = GetBuffer(4).WriteInt(testInt);
+            Assert.True(littleEndianBytes.SequenceEqual(buf.Array));
+        }
+
+        [Fact]
+        public void UnpooledDirectByteBuffer_write_long_little_endian()
+        {
+            Assert.True(BitConverter.IsLittleEndian, "this spec is designed for little endian hardware");
+            var testLong = -4L;
+            var littleEndianBytes = BitConverter.GetBytes(testLong);
+            var buf = GetBuffer(8).WriteLong(testLong);
+            Assert.True(littleEndianBytes.SequenceEqual(buf.Array));
+        }
+
+        [Fact]
+        public void UnpooledDirectByteBuffer_write_short_little_endian()
+        {
+            Assert.True(BitConverter.IsLittleEndian, "this spec is designed for little endian hardware");
+            short testShort = -4;
+            var littleEndianBytes = BitConverter.GetBytes(testShort);
+            var buf = GetBuffer(2).WriteShort(testShort);
+            Assert.True(littleEndianBytes.SequenceEqual(buf.Array));
         }
     }
 }

--- a/tests/Helios.Tests/Codecs/LengthFieldBasedFrameDecoderTests.cs
+++ b/tests/Helios.Tests/Codecs/LengthFieldBasedFrameDecoderTests.cs
@@ -18,13 +18,13 @@ namespace Helios.Tests.Codecs
             var ch = new EmbeddedChannel(new LengthFieldBasedFrameDecoder(5, 0, 4, 0, 4, false));
             for (var i = 0; i < 2; i++)
             {
-                Assert.False(ch.WriteInbound(Unpooled.WrappedBuffer(new byte[] {0, 0, 0, 2})));
+                Assert.False(ch.WriteInbound(Unpooled.WrappedBuffer(new byte[] {2, 0, 0, 0})));
                 Assert.Throws<TooLongFrameException>(() =>
                 {
                     Assert.True(ch.WriteInbound(Unpooled.WrappedBuffer(new byte[] {0, 0})));
                     Assert.True(false, typeof (DecoderException).Name + " must be raised.");
                 });
-                ch.WriteInbound(Unpooled.WrappedBuffer(new byte[] {0, 0, 0, 1, (byte) 'A'}));
+                ch.WriteInbound(Unpooled.WrappedBuffer(new byte[] {1, 0, 0, 0, (byte) 'A'}));
                 var buf = ch.ReadInbound<IByteBuf>();
                 var iso = Encoding.GetEncoding("ISO-8859-1");
                 Assert.Equal("A", iso.GetString(buf.ToArray()));
@@ -35,23 +35,29 @@ namespace Helios.Tests.Codecs
         [Fact]
         public void TestFailFastTooLongFrameRecovery()
         {
+            var buf = Unpooled.Buffer();
+            buf.WriteInt(32);
+            for (var i = 0; i < 32; i++)
+                buf.WriteByte(i);
+            buf.WriteInt(1);
+            buf.WriteByte('a');
             var ch = new EmbeddedChannel(
-                new LengthFieldBasedFrameDecoder(5, 0, 4, 0, 4));
+                new LengthFieldBasedFrameDecoder(16,0,4));
 
-            for (var i = 0; i < 2; i++)
+            Assert.Throws<TooLongFrameException>(() =>
             {
-                Assert.Throws<TooLongFrameException>(() =>
-                {
-                    Assert.True(ch.WriteInbound(Unpooled.WrappedBuffer(new byte[] {0, 0, 0, 2})));
-                    Assert.True(false, typeof (DecoderException).Name + " must be raised.");
-                });
+                ch.WriteInbound(buf.ReadSlice(14).Retain());
+            });
+            Assert.True(ch.WriteInbound(buf.ReadSlice(buf.ReadableBytes).Retain()));
+            Assert.True(ch.Finish());
 
-                ch.WriteInbound(Unpooled.WrappedBuffer(new byte[] {0, 0, 0, 0, 0, 1, (byte) 'A'}));
-                var buf = ch.ReadInbound<IByteBuf>();
-                var iso = Encoding.GetEncoding("ISO-8859-1");
-                Assert.Equal("A", iso.GetString(buf.ToArray()));
-                buf.Release();
-            }
+            var b = ch.ReadInbound<IByteBuf>();
+            Assert.Equal(5, b.ReadableBytes);
+            Assert.Equal(1, b.ReadInt());
+            Assert.Equal('a', (char)b.ReadByte());
+
+            Assert.Null(ch.ReadInbound<IByteBuf>());
+            ch.Finish();
         }
     }
 }

--- a/tests/Helios.Tests/Codecs/LengthFieldPrependerSpecs.cs
+++ b/tests/Helios.Tests/Codecs/LengthFieldPrependerSpecs.cs
@@ -90,10 +90,10 @@ namespace Helios.Tests.Codecs
             Assert.Equal(4, buf.ReadableBytes);
             var writtenBytes = new byte[buf.ReadableBytes];
             buf.GetBytes(0, writtenBytes);
-            Assert.Equal(1, writtenBytes[0]);
+            Assert.Equal(0, writtenBytes[0]);
             Assert.Equal(0, writtenBytes[1]);
             Assert.Equal(0, writtenBytes[2]);
-            Assert.Equal(0, writtenBytes[3]);
+            Assert.Equal(1, writtenBytes[3]);
             //buf.Release();
 
             buf = ch.ReadOutbound<IByteBuf>();


### PR DESCRIPTION
Fixes a bug where we claimed to be using `LittleEndian`, but were actually encoding in `BigEndian`.